### PR TITLE
bq: add task labelling

### DIFF
--- a/bq
+++ b/bq
@@ -187,3 +187,4 @@ fi
 ID=`date +%s`.$$.${LABEL//[^a-z0-9_.-]/}
 pwd                 > $QDIR/q/$ID
 printf "%s\n" "$@" >> $QDIR/q/$ID
+echo "$ID"

--- a/bq
+++ b/bq
@@ -174,8 +174,16 @@ _work_1() {
 [ -z "$1" ] && exec sh -c "${BQ_FILEMANAGER:-vifm} $QDIR"
 
 # ----------------------------------------------------------------------
-
 # some command was given; add it to the queue
-ID=`date +%s`.$$.${1//[^a-z0-9_.-]/}
+
+# check for a task label via `bq -L label cmd ...`
+if [ "$1" == "-L" ]; then
+    [ -z "$3" ] && die "-L needs a task label"
+    LABEL=$2; shift; shift
+else
+    LABEL=$1
+fi
+
+ID=`date +%s`.$$.${LABEL//[^a-z0-9_.-]/}
 pwd                 > $QDIR/q/$ID
 printf "%s\n" "$@" >> $QDIR/q/$ID

--- a/bq
+++ b/bq
@@ -90,7 +90,9 @@ _work_1() {
         mv $ID.running.$$ $ID.exitcode=$ec
         [ "$ec" = "0" ] && mv $ID.* OK
         echo " # $ec" >> w/$$
-        notify-send "`wc -l w/$$`" "`tail -1 w/$$`"
+        if command -v notify-send &> /dev/null; then
+            notify-send "`wc -l w/$$`" "`tail -1 w/$$`"
+        fi
     fi
 }
 

--- a/bq.mkd
+++ b/bq.mkd
@@ -115,8 +115,9 @@ so far.
 
 # files in the QDIR
 
-The Q directory, which is by default `/dev/shm/bq-$USER-default`, contains all
-the files that make bq tick.  An explanation of what they are follows.
+The Q directory, which is by default `/dev/shm/bq-$USER-default` (override by
+setting `$QDIR`), contains all the files that make bq tick. An explanation of
+what they are follows:
 
 (Side note: why `/dev/shm`?  I prefer /dev/shm for output files; I assume most
 jobs output is small enough (otherwise you would have redirected it!) I'm more

--- a/bq.mkd
+++ b/bq.mkd
@@ -71,9 +71,9 @@ Start a task by just prefixing the command with "bq":
 If a worker is free it will start running immediately, otherwise it will run
 when a worker becomes free.
 
-Call `bq -L LABEL COMMAND...` to give the task a custom label, otherwise it
-uses the first word of the command. Spaces/special characters will be stripped
-from labels.
+bq will print the task file identifier. Call `bq -L LABEL COMMAND...` to give
+the task a custom label, otherwise it uses the first word of the command.
+Spaces/special characters will be stripped from labels.
 
 You can cancel a task in queue by simply running `bq`, which opens up your file
 manager, and deleting the appropriate file in the `q` directory.

--- a/bq.mkd
+++ b/bq.mkd
@@ -41,6 +41,7 @@ something that just uses bash is very useful.
     # start a couple of jobs
     bq some long running command
     bq another command  # will run after the previous one completes
+    bq -L mytask next command  # will use mytask as a label
     # examine the output directory at any time
     bq                              # uses vifm as the file manager
     export BQ_FILEMANAGER=mc; bq    # env var overrides default
@@ -70,7 +71,13 @@ Start a task by just prefixing the command with "bq":
 If a worker is free it will start running immediately, otherwise it will run
 when a worker becomes free.
 
-You can cancel a task in queue by simply running `bq`, which opens up your file manager, and deleting the appropriate file in the `q` directory.
+Call `bq -L LABEL COMMAND...` to give the task a custom label, otherwise it
+uses the first word of the command. Spaces/special characters will be stripped
+from labels.
+
+You can cancel a task in queue by simply running `bq`, which opens up your file
+manager, and deleting the appropriate file in the `q` directory.
+
 
 # status
 
@@ -122,8 +129,8 @@ worker exits, this file is renamed to have a ".exited" extension.
 
 **Tasks**: each task has an **ID**, which looks like
 `1549791234.23456.ffmpeg`.  The first bit is a timestamp (`date +%s`), the
-next is the PID that submitted the job, the third bit is the first word of the
-command (in our example, "ffmpeg").
+next is the PID that submitted the job, the third bit is the label, which
+defaults to the first word of the command (in our example, "ffmpeg").
 
 Here's the lifecycle of a task in terms of the filenames you will see:
 


### PR DESCRIPTION
A few minor improvements to bq...

1. Print out the Task ID (eg: `1633694777.1605.pwd`) when enqueuing tasks.
2. Document `$QDIR`
3. Support a custom task label when enqueuing tasks via `bq -L mylabel mycommand` (defaults to the first word of command, like now).
4. Check for existence of `notify-send` before invoking.

Example:
```console
$ for I in {1..4}; do bq -L task$I sleep 10; done
1633694536.1049.task1
1633694536.1054.task2
1633694536.1064.task3
1633694536.1069.task4
$ ./bq pwd
1633694777.1605.pwd

$ find /dev/shm/bq--default/
/dev/shm/bq--default/
/dev/shm/bq--default/1633694536.1054.task2.2
/dev/shm/bq--default/1633694536.1054.task2.1
/dev/shm/bq--default/1633694536.1054.task2.running.1023
/dev/shm/bq--default/OK
/dev/shm/bq--default/OK/1633694777.1605.pwd.exitcode=0
/dev/shm/bq--default/OK/1633694777.1605.pwd.2
/dev/shm/bq--default/OK/1633694777.1605.pwd.1
/dev/shm/bq--default/OK/1633694536.1049.task1.exitcode=0
/dev/shm/bq--default/OK/1633694536.1049.task1.2
/dev/shm/bq--default/OK/1633694536.1049.task1.1
/dev/shm/bq--default/q
/dev/shm/bq--default/q/1633694536.1069.task4
/dev/shm/bq--default/q/1633694536.1064.task3
/dev/shm/bq--default/w
/dev/shm/bq--default/w/1023
```